### PR TITLE
Fix for use of `/bin` instead of `/usr/bin`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ build() {{
         try!(write!(output, r#"
 package() {{
     cd $srcdir
-    cargo install --root="$pkgdir" --git={}
+    cargo install --root="$pkgdir/usr" --git={}
 }}
 "#, repo));
     } else {


### PR DESCRIPTION
Cargo installs binaries in a `bin` directory when Archlinux has moved to `/bin` only being a symlink.

Without this, packages built will have filesystem conflicts between the `/bin` symlink and the package's `bin` directory