### PR TITLE
CargoPackage: Make keywords optional

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ struct CargoPackage {
     version: String,
     description: Option<String>,
     authors: Vec<String>,
-    keywords: Vec<String>,
+    keywords: Option<Vec<String>>,
     repository: Option<String>,
     homepage: Option<String>,
     license: Option<String>,


### PR DESCRIPTION
When creating a new Cargo project, `keywords` is not autopopulated. Nor is it needed to create a `PKGBUILD`. Therefore, I propose that it should be optional.

In fact, simply `cargo run`ning inside `cargo-pkgbuild` produces an error because `cargo-pkgbuild` doesn't have any keywords! Hehe