### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+
+[[package]]
 name = "cargo-pkgbuild"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "serde",
  "serde_json",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,13 +9,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-pkgbuild"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
+ "locate-cargo-manifest",
  "serde",
  "serde_json",
  "toml",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -23,6 +56,21 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
+name = "locate-cargo-manifest"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db985b63431fe09e8d71f50aeceffcc31e720cb86be8dad2f38d084c5a328466"
+dependencies = [
+ "json",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -47,6 +95,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "semver"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-anyhow = { version = "1.0" }
+anyhow = "1.0"
 cargo_metadata = "0.14.2"
 locate-cargo-manifest = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0" }
+cargo_metadata = "0.14.2"
+locate-cargo-manifest = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context, Result};
 use cargo_metadata::Package;
-
-type Result<T> = anyhow::Result<T>;
 
 const MANIFEST_FILENAME: &str = "Cargo.toml";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Write, path::PathBuf, process};
+use std::{fs::File, io::Write, path::PathBuf};
 
 use anyhow::{anyhow, Context};
 use cargo_metadata::Package;
@@ -83,19 +83,12 @@ package() {{
     Ok(())
 }
 
-fn main() {
-    fn exec() -> Result<()> {
-        let manifest_path = locate_cargo_manifest::locate_manifest()
-            .with_context(|| anyhow!("Failed to locate `{MANIFEST_FILENAME}`"))?;
-        let manifest = parse_manifest(&manifest_path)
-            .with_context(|| anyhow!("Failed to parse `{}`", manifest_path.display()))?;
-        let mut pkgbuild = File::create("PKGBUILD").context("Failed to create PKGBUILD file")?;
-        generate_pkgbuild(&manifest, &mut pkgbuild).context("Failed to generate PKGBUILD")?;
-        Ok(())
-    }
-
-    if let Err(e) = exec() {
-        eprintln!("Error: {e:?}");
-        process::exit(1)
-    }
+fn main() -> Result<()> {
+    let manifest_path = locate_cargo_manifest::locate_manifest()
+        .with_context(|| anyhow!("Failed to locate `{MANIFEST_FILENAME}`"))?;
+    let manifest = parse_manifest(&manifest_path)
+        .with_context(|| anyhow!("Failed to parse `{}`", manifest_path.display()))?;
+    let mut pkgbuild = File::create("PKGBUILD").context("Failed to create PKGBUILD file")?;
+    generate_pkgbuild(&manifest, &mut pkgbuild).context("Failed to generate PKGBUILD")?;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{self, Command};
 
 use anyhow::Context;
 use serde::Deserialize;
@@ -110,8 +110,16 @@ package() {{
 }
 
 fn main() {
-    let manifest_path = get_manifest_path().unwrap();
-    let manifest = read_manifest(&manifest_path).unwrap();
-    let mut pkgbuild = File::create("PKGBUILD").unwrap();
-    generate_pkgbuild(&manifest, &mut pkgbuild).unwrap();
+    fn exec() -> anyhow::Result<()> {
+        let manifest_path = get_manifest_path().context("Failed to get manifest path")?;
+        let manifest = read_manifest(&manifest_path).context("Failed to read project manifest")?;
+        let mut pkgbuild = File::create("PKGBUILD").context("Failed to create PKGBUILD file")?;
+        generate_pkgbuild(&manifest, &mut pkgbuild).context("Failed to generate PKGBUILD")?;
+        Ok(())
+    }
+
+    if let Err(e) = exec() {
+        eprintln!("Error: {e:?}");
+        process::exit(1)
+    }
 }


### PR DESCRIPTION
This PR contains the following:
1. All functions now propagate their errors upwards.
2. Errors are now printed in `main` instead of `unwrap`ped
3. The Cargo.toml handling code is replaced by crates to improve the related error messages (these errors are the most common: e.g. trying to use the program outside of a rust repository)